### PR TITLE
feat(eros): Kodi couch shell (Jellyfin + Steam Link + Moonlight)

### DIFF
--- a/hosts/eros/configuration.nix
+++ b/hosts/eros/configuration.nix
@@ -1,6 +1,74 @@
 { inputs, lib, pkgs, config, ... }:
 let
   steamlink = pkgs.callPackage ../../packages/steamlink {};
+
+  # Kodi is the couch shell. The GBM build renders straight on KMS/DRM (no X,
+  # no Wayland) — the same direct-to-framebuffer path the old Steam Link kiosk
+  # used, but it takes the DRM master via logind so it cooperates with greetd's
+  # seat. Bundle the client addons we want available out of the box.
+  kodiPkg = pkgs.kodi-gbm.withPackages (p: with p; [
+    jellycon              # Jellyfin client
+    youtube               # YouTube
+    inputstream-adaptive  # adaptive (DASH/HLS) streams youtube et al. rely on
+    inputstreamhelper
+  ]);
+
+  # Single-KMS-app session model. Only one fullscreen app may own the DRM
+  # master at a time, and Kodi-on-GBM does not reliably hand KMS to a nested
+  # eglfs child — so rather than launch the streamers *inside* Kodi we switch
+  # the whole greetd session. eros-shell reruns on every session exit; a marker
+  # file picks the next app and defaults back to Kodi, so quitting Steam Link or
+  # Moonlight drops you back on the Kodi home screen. A Kodi/streamer crash also
+  # just re-enters eros-shell (empty marker → Kodi), so the TV never strands.
+  sessionMarker = "/tmp/eros-session-next";
+
+  # Qt eglfs-on-KMS env shared by the Qt streamers (Steam Link, Moonlight).
+  qtKmsEnv = ''
+    export QT_QPA_PLATFORM=eglfs
+    export QT_QPA_EGLFS_INTEGRATION=eglfs_kms
+    export QT_QPA_EGLFS_KMS_ATOMIC=1
+    export QT_QPA_EGLFS_HIDECURSOR=1
+  '';
+
+  erosShell = pkgs.writeShellScript "eros-shell" ''
+    target=kodi
+    if [ -r ${sessionMarker} ]; then
+      target=$(${pkgs.coreutils}/bin/cat ${sessionMarker})
+      ${pkgs.coreutils}/bin/rm -f ${sessionMarker}
+    fi
+    case "$target" in
+      steamlink)
+        ${qtKmsEnv}
+        exec ${steamlink}/bin/steamlink
+        ;;
+      moonlight)
+        ${qtKmsEnv}
+        exec ${pkgs.moonlight-qt}/bin/moonlight
+        ;;
+      *)
+        exec ${kodiPkg}/bin/kodi
+        ;;
+    esac
+  '';
+
+  # One no-arg launcher per streamer, invoked from a Kodi favourite via
+  # System.Exec: record which app to run next, then SIGTERM Kodi (the GBM binary
+  # is `kodi.bin`, which shuts down cleanly) so greetd reruns eros-shell into it.
+  mkLaunch = app: pkgs.writeShellScript "eros-launch-${app}" ''
+    ${pkgs.coreutils}/bin/echo "${app}" > ${sessionMarker}
+    ${pkgs.procps}/bin/pkill -TERM -x kodi.bin || true
+  '';
+  launchSteamlink = mkLaunch "steamlink";
+  launchMoonlight = mkLaunch "moonlight";
+
+  # Shipped to ~/.kodi/userdata so the streamers appear under Kodi's Favourites,
+  # navigable with the controller.
+  kodiFavourites = pkgs.writeText "favourites.xml" ''
+    <favourites>
+      <favourite name="Steam Link">System.Exec("${launchSteamlink}")</favourite>
+      <favourite name="Moonlight">System.Exec("${launchMoonlight}")</favourite>
+    </favourites>
+  '';
 in
 {
   imports = [
@@ -82,18 +150,30 @@ in
       gpu_mem = { enable = true; value = 256; };
     };
 
-    # Force 1080p output. The Pi 4's BCM2711 can only DMA-address the lower
-    # 1 GiB of RAM, so VC4 has to bounce framebuffers through swiotlb. A single
-    # 4K BGRA framebuffer is ~32 MiB and overruns the swiotlb pool, which
-    # presents as Steam Link freezing and then crashing the second a stream
-    # starts (the kernel logs `vc4-drm gpu: swiotlb buffer is full`). 1080p
-    # buffers are 8 MiB and fit comfortably. Steam Link's host-side encoder
-    # streams 1080p by default anyway. HDMI-A-2 is the active port (HDMI0 on
-    # the Pi 4 board); A-1 is the second port and disconnected here.
+    # swiotlb: the Pi 4's BCM2711 can only DMA-address the lower 1 GiB of RAM,
+    # so VC4 bounces framebuffers through swiotlb. A 4K BGRA framebuffer is
+    # ~32 MiB and overruns the pool (kernel logs `vc4-drm gpu: swiotlb buffer is
+    # full`, Steam Link then freezes and crashes the moment a stream starts);
+    # the modest resolutions forced below fit comfortably.
+    #
+    # video=...e: the display is an LG 4K TV (EDID manufacturer GSM, name
+    # "LG TV SSCR2"; native timing 3840x2160@30). We deliberately force 1080p
+    # rather than the native 4K — a 4K framebuffer is ~33 MiB and overruns the
+    # swiotlb pool above, and the TV upscales 1080p fine (Steam Link streams
+    # 1080p regardless). The trailing `e` ("output forced on") is the full-KMS
+    # equivalent of the legacy config.txt `hdmi_force_hotplug=1` (which
+    # vc4-kms-v3d + disable_fw_kms_setup ignore). It matters on a TV: TVs drop
+    # HPD/EDID when powered off or on another input, and without `e` a boot
+    # while the TV is off leaves the connector disconnected → vc4 builds no CRTC
+    # (`Cannot find any crtc or sizes`) → Steam Link's eglfs_kms backend crashes
+    # for want of an output, staying blank even once the TV comes back. Forcing
+    # the connector pins it to 1080p regardless of HPD state. Steam Link renders
+    # on HDMI-A-1 (eglfs picks the first forced connector); both ports are
+    # forced so the cable works in either socket.
     boot.kernelParams = [
       "swiotlb=131072"
-      "video=HDMI-A-1:1920x1080@60"
-      "video=HDMI-A-2:1920x1080@60"
+      "video=HDMI-A-1:1920x1080@60e"
+      "video=HDMI-A-2:1920x1080@60e"
     ];
 
     # Steam Link wants /dev/uinput for virtual controller emulation, and xpadneo
@@ -136,8 +216,9 @@ in
       raspberrypi-eeprom
       neovim
       btop
-      cage
       steamlink
+      moonlight-qt
+      kodiPkg        # the addon-bundled GBM build; also puts kodi-send on PATH
     ];
 
     # Audio: pipewire over HDMI. Steam Link's bundled SDL3 talks to PulseAudio,
@@ -155,35 +236,37 @@ in
     # the package so changes track upstream.
     services.udev.packages = [ steamlink ];
 
-    # Boot straight into Steam Link on the framebuffer via Qt's eglfs plugin —
-    # no cage, no XWayland. Cage's wlroots 0.19 segfaults in
-    # xwayland_surface_destroy the moment Steam Link reparents to start a
-    # stream, which presented as "input device cannot be mapped to output
-    # device". eglfs talks to KMS/GBM directly, dropping two crash-prone layers.
-    # default_session re-runs the kiosk so a crash doesn't strand the TV on a
-    # blank tty.
+    # Steam Controller (the 2.4 GHz USB dongle). steam-hardware ships the udev
+    # rules; the kernel hid-steam driver exposes it as a standard gamepad and
+    # emulates keyboard/mouse ("lizard mode") so it can drive Kodi's UI, while
+    # Steam Link and Moonlight see it as a controller directly.
+    hardware.steam-hardware.enable = true;
+
+    # Boot into the Kodi couch shell via greetd; eros-shell is the session
+    # dispatcher (see the let-binding above) that also lets Kodi favourites
+    # switch the session into Steam Link or Moonlight and back.
     services.greetd = {
       enable = true;
-      settings = let
-        kiosk = pkgs.writeShellScript "steamlink-kiosk" ''
-          export QT_QPA_PLATFORM=eglfs
-          export QT_QPA_EGLFS_INTEGRATION=eglfs_kms
-          export QT_QPA_EGLFS_KMS_ATOMIC=1
-          # Hide the cursor; eglfs draws one by default and there's no mouse.
-          export QT_QPA_EGLFS_HIDECURSOR=1
-          exec ${steamlink}/bin/steamlink
-        '';
-      in {
+      settings = {
         initial_session = {
-          command = toString kiosk;
+          command = toString erosShell;
           user = "cramt";
         };
         default_session = {
-          command = toString kiosk;
+          command = toString erosShell;
           user = "cramt";
         };
       };
     };
+
+    # Ship the Favourites menu (Steam Link / Moonlight launchers) into Kodi's
+    # userdata. tmpfiles creates the dirs so the symlink lands before Kodi's
+    # first run; the target is read-only in the store, which is fine for a kiosk.
+    systemd.tmpfiles.rules = [
+      "d /home/cramt/.kodi 0755 cramt users - -"
+      "d /home/cramt/.kodi/userdata 0755 cramt users - -"
+      "L+ /home/cramt/.kodi/userdata/favourites.xml - - - - ${kodiFavourites}"
+    ];
 
     services.dbus.enable = true;
 

--- a/hosts/eros/configuration.nix
+++ b/hosts/eros/configuration.nix
@@ -236,11 +236,26 @@ in
     # the package so changes track upstream.
     services.udev.packages = [ steamlink ];
 
-    # Steam Controller (the 2.4 GHz USB dongle). steam-hardware ships the udev
-    # rules; the kernel hid-steam driver exposes it as a standard gamepad and
-    # emulates keyboard/mouse ("lizard mode") so it can drive Kodi's UI, while
-    # Steam Link and Moonlight see it as a controller directly.
+    # Steam Controller. steam-hardware ships the udev rules (also covers the
+    # 2.4 GHz dongle if it ever moves here). The gf keeps the dongle on her
+    # desktop, so eros uses the controller over Bluetooth, where it presents as
+    # a HID mouse+keyboard ("lizard mode") — perfect for driving Kodi, and Steam
+    # Link promotes it to a real gamepad for streamed Steam sessions.
     hardware.steam-hardware.enable = true;
+    hardware.bluetooth.enable = true;
+
+    # Re-seed the controller's Bluetooth bond from 1Password so the pairing
+    # survives SD-card reflashes (BlueZ bonds live on the SD card otherwise).
+    # Paired once by hand; the bond's `info` file is stored at
+    # op://Homelab/SteamControllerBond/info. Requires /etc/opnix-token present.
+    myNixOS.declarativeBluetooth = {
+      enable = true;
+      devices.steamController = {
+        adapter = "DC:A6:32:0B:27:48";   # eros onboard radio (stable across reflash)
+        address = "F8:FC:54:D5:6A:06";   # controller bond/identity address
+        secretRef = "op://Homelab/SteamControllerBond/info";
+      };
+    };
 
     # Boot into the Kodi couch shell via greetd; eros-shell is the session
     # dispatcher (see the let-binding above) that also lets Kodi favourites

--- a/modules/networking/declarative-bluetooth.nix
+++ b/modules/networking/declarative-bluetooth.nix
@@ -1,0 +1,108 @@
+# Declarative BlueZ bonds, re-seeded from opnix (1Password).
+#
+# A Bluetooth pairing lives on the host at /var/lib/bluetooth/<adapter>/<device>/
+# (the `info` file holds the long-term keys), so a full disk/SD reflash wipes it
+# and you'd have to re-pair. This module stores each device's `info` file as a
+# 1Password secret and, on every boot, fetches it via opnix and installs it back
+# into place, then nudges bluetooth to load it — so bonds survive reflashes.
+#
+# It is deliberately self-contained: enabling it pulls in ONLY the bond secrets
+# (not any other host's opnix secret bundle), so it's reusable on any host for
+# any already-bonded device. Pair the device once by hand, stash its `info` file
+# in 1Password, then declare it here.
+{ ... }: {
+  flake.nixosModules."networking.declarative-bluetooth" = { config, lib, pkgs, ... }:
+  let
+    cfg = config.myNixOS.declarativeBluetooth;
+    ucfirst = s: (lib.toUpper (builtins.substring 0 1 s)) + (builtins.substring 1 (-1) s);
+    # opnix requires camelCase secret keys, so derive one per device id.
+    secretName = name: "bluetoothBond${ucfirst name}";
+  in {
+    options.myNixOS.declarativeBluetooth = {
+      enable = lib.mkEnableOption "declarative BlueZ bonds re-seeded from opnix";
+
+      tokenFile = lib.mkOption {
+        type = lib.types.path;
+        default = "/etc/opnix-token";
+        description = "1Password service-account token file used by opnix.";
+      };
+
+      devices = lib.mkOption {
+        default = {};
+        description = ''
+          Bonded Bluetooth devices to re-seed declaratively. The attribute name
+          is a short camelCase id (e.g. `steamController`).
+
+          To onboard a device: pair it once normally, then copy
+          /var/lib/bluetooth/<adapter>/<address>/info into a 1Password field and
+          point `secretRef` at it.
+        '';
+        type = lib.types.attrsOf (lib.types.submodule {
+          options = {
+            adapter = lib.mkOption {
+              type = lib.types.str;
+              example = "DC:A6:32:0B:27:48";
+              description = "MAC of this host's Bluetooth adapter. Stable across reflashes (it's in the radio).";
+            };
+            address = lib.mkOption {
+              type = lib.types.str;
+              example = "F8:FC:54:D5:6A:06";
+              description = "MAC the device is bonded under (its identity/static address).";
+            };
+            secretRef = lib.mkOption {
+              type = lib.types.str;
+              example = "op://Homelab/SteamControllerBond/info";
+              description = "opnix reference to the BlueZ `info` bond-file contents.";
+            };
+          };
+        });
+      };
+    };
+
+    config = lib.mkIf (cfg.enable && cfg.devices != {}) {
+      assertions = [{
+        assertion = config.hardware.bluetooth.enable;
+        message = "myNixOS.declarativeBluetooth requires hardware.bluetooth.enable = true.";
+      }];
+
+      # Pull ONLY the bond secrets, so enabling this doesn't drag in the rest of
+      # a host's opnix configuration. tokenFile is mkDefault so a host that also
+      # uses myNixOS.opnix-secrets keeps a single shared token definition.
+      services.onepassword-secrets = {
+        enable = true;
+        tokenFile = lib.mkDefault cfg.tokenFile;
+        secrets = lib.mapAttrs' (name: dev:
+          lib.nameValuePair (secretName name) {
+            reference = dev.secretRef;
+            mode = "0600";
+          })
+          cfg.devices;
+      };
+
+      # opnix fetches secrets after the network is up (so well after bluetooth
+      # has already started); rather than block bluetooth on the network, seed
+      # the bond once the secret lands and then restart bluetooth to load it.
+      systemd.services = lib.mapAttrs' (name: dev:
+        lib.nameValuePair "bluetooth-bond-${name}" {
+          description = "Seed BlueZ bond for ${name} from its opnix secret";
+          after = [ "opnix-secrets.service" ];
+          wants = [ "opnix-secrets.service" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+          };
+          script = ''
+            set -eu
+            src=${config.services.onepassword-secrets.secretPaths.${secretName name}}
+            dir=/var/lib/bluetooth/${dev.adapter}/${dev.address}
+            install -d -m700 -o root -g root "$dir"
+            install -m600 -o root -g root "$src" "$dir/info"
+            # BlueZ only reads bonds at startup; reload it now that the bond exists.
+            ${pkgs.systemd}/bin/systemctl try-restart bluetooth.service || true
+          '';
+        })
+        cfg.devices;
+    };
+  };
+}


### PR DESCRIPTION
Reworks **eros** (the RPi 4 on the LG 4K TV) from a Steam Link–only kiosk into a Kodi-based couch box.

## What changed
- **Kodi (`kodi-gbm`) is the boot shell** via greetd — renders directly on KMS/DRM (no X/Wayland), takes the DRM master through logind. Bundles `jellycon` (Jellyfin), `youtube`, `inputstream-adaptive`, `inputstreamhelper`.
- **Single-KMS-app session dispatcher** (`eros-shell`): Kodi-on-GBM can't hand the DRM master to a nested eglfs child, so instead of launching the streamers *inside* Kodi we switch the whole greetd session. A `/tmp` marker selects the next app and defaults back to Kodi, so quitting Steam Link / Moonlight (or a crash) returns to the Kodi home screen.
- **Steam Link + Moonlight** exposed as Kodi **Favourites** (`favourites.xml` shipped via tmpfiles); each favourite records the target and SIGTERMs Kodi so greetd re-enters the dispatcher into that streamer.
- **Steam Controller** support via `hardware.steam-hardware` (USB dongle; `hid-steam` lizard-mode drives Kodi, native in Steam Link/Moonlight).
- Added `moonlight-qt`, kept `steamlink`, dropped unused `cage`.
- HDMI forced to **1080p** for the 4K TV (a 4K framebuffer overruns the Pi 4 swiotlb pool and crashes Steam Link).

## Test plan
- [ ] ARM CI build of `nixosConfigurations.eros` is green
- [ ] Deploy to eros; Kodi boots on the TV via greetd
- [ ] Jellyfin/YouTube addons load; controller navigates
- [ ] Favourites switch into Steam Link / Moonlight and back to Kodi