### PR TITLE
eros v2: sway couch shell (drop Kodi)

### DIFF
--- a/hosts/eros/configuration.nix
+++ b/hosts/eros/configuration.nix
@@ -153,6 +153,15 @@ in
     home-manager = {
       useGlobalPkgs = true;
       useUserPackages = true;
+      # Back up (don't clobber) any pre-existing dotfile that collides with an
+      # HM-managed one. Without this, HM activation hard-fails at
+      # checkLinkTargets on the FIRST collision and writes NONE of its files —
+      # so a stray ~/.config/mozilla/firefox/profiles.ini (left by a manual
+      # Firefox run before first deploy) aborts the whole activation, leaving
+      # ~/.config/sway/config unwritten and sway falling back to its stock
+      # default config (blue wallpaper + bar, no couch shell). Backing up keeps
+      # deploys/reflashes idempotent against leftover state.
+      backupFileExtension = "hm-bak";
       users.cramt = import ./home.nix;
       # desktop.niri (imported unconditionally by mkSystem, like every nixos
       # module) makes niri-flake inject its HM module into sharedModules for all
@@ -240,6 +249,16 @@ in
           initial_session = session;
           default_session = session;
         };
+    };
+
+    # greetd launches the system sway, which reads ~/.config/sway/config written
+    # by HM activation. Order greetd after that unit so a fresh-reflash boot
+    # can't start sway before its config exists (which would drop it to the stock
+    # default config with no couch shell). home-manager-cramt.service is a
+    # oneshot RemainAfterExit unit, so `after` waits for it to finish.
+    systemd.services.greetd = {
+      after = [ "home-manager-cramt.service" ];
+      wants = [ "home-manager-cramt.service" ];
     };
 
     services.dbus.enable = true;

--- a/hosts/eros/configuration.nix
+++ b/hosts/eros/configuration.nix
@@ -1,176 +1,8 @@
 { inputs, lib, pkgs, config, ... }:
 let
+  # Steam Link (patched, aarch64). Kept here for its udev rules + uinput
+  # fragment; the launcher itself runs the copy home-manager installs.
   steamlink = pkgs.callPackage ../../packages/steamlink {};
-
-  # Kodi is the couch shell. The GBM build renders straight on KMS/DRM (no X,
-  # no Wayland) — the same direct-to-framebuffer path the old Steam Link kiosk
-  # used, but it takes the DRM master via logind so it cooperates with greetd's
-  # seat. Bundle the client addons we want available out of the box.
-  kodiPkg = pkgs.kodi-gbm.withPackages (p: with p; [
-    jellycon              # Jellyfin client
-    youtube               # YouTube
-    inputstream-adaptive  # adaptive (DASH/HLS) streams youtube et al. rely on
-    inputstreamhelper
-  ]);
-
-  # Single-KMS-app session model. Only one fullscreen app may own the DRM
-  # master at a time, and Kodi-on-GBM does not reliably hand KMS to a nested
-  # eglfs child — so rather than launch the streamers *inside* Kodi we switch
-  # the whole greetd session. eros-shell reruns on every session exit; a marker
-  # file picks the next app and defaults back to Kodi, so quitting Steam Link or
-  # Moonlight drops you back on the Kodi home screen. A Kodi/streamer crash also
-  # just re-enters eros-shell (empty marker → Kodi), so the TV never strands.
-  sessionMarker = "/tmp/eros-session-next";
-
-  # Firefox for the Nebula kiosk, with uBlock Origin + SponsorBlock force-
-  # installed via enterprise policy (declarative + reflash-safe; Firefox fetches
-  # the XPIs from AMO on first launch).
-  firefoxKiosk = pkgs.firefox.override {
-    extraPolicies.ExtensionSettings = {
-      "uBlock0@raymondhill.net" = {
-        installation_mode = "force_installed";
-        install_url = "https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi";
-      };
-      "sponsorBlocker@ajay.app" = {
-        installation_mode = "force_installed";
-        install_url = "https://addons.mozilla.org/firefox/downloads/latest/sponsorblock/latest.xpi";
-      };
-    };
-  };
-
-  # sway is the Nebula compositor (via programs.sway, which provides the wrapped
-  # package + portals/dbus/polkit). We pin 1080p — cage took the TV's 4K@30
-  # preferred mode, which overran the Pi's V3D max texture size (GL_INVALID_VALUE
-  # spam) and was heavier. Firefox is Wayland-native, so XWayland is disabled.
-  # Closing Firefox (or the exit keybinds) ends sway, dropping back to Kodi.
-  sway = config.programs.sway.package;
-  swayNebulaConfig = pkgs.writeText "sway-nebula.conf" ''
-    output "*" mode 1920x1080
-    default_border none
-    xwayland disable
-    bindsym Mod1+F4 exec ${sway}/bin/swaymsg exit
-    bindsym Ctrl+q exec ${sway}/bin/swaymsg exit
-    exec "${firefoxKiosk}/bin/firefox --kiosk https://nebula.tv; ${sway}/bin/swaymsg exit"
-  '';
-
-  # Qt eglfs-on-KMS env shared by the Qt streamers (Steam Link, Moonlight).
-  qtKmsEnv = ''
-    export QT_QPA_PLATFORM=eglfs
-    export QT_QPA_EGLFS_INTEGRATION=eglfs_kms
-    export QT_QPA_EGLFS_KMS_ATOMIC=1
-    export QT_QPA_EGLFS_HIDECURSOR=1
-  '';
-
-  # Persistent session supervisor. greetd EXITS whenever its session command
-  # exits ("greeter exited without creating a session"), so we must not rely on
-  # greetd relaunching between apps. Instead this loop IS the greetd session and
-  # never returns: it runs the selected app, and when that app exits it loops
-  # back and re-reads the marker (default: Kodi). App switching thus happens
-  # inside one stable greetd session — no greetd churn, no crash-loops. A Kodi
-  # favourite writes the marker and kills Kodi (see mkLaunch); Kodi exits, the
-  # loop launches the chosen app; exiting that app drops back to Kodi.
-  erosShell = pkgs.writeShellScript "eros-shell" ''
-    while true; do
-      target=kodi
-      if [ -r ${sessionMarker} ]; then
-        target=$(${pkgs.coreutils}/bin/cat ${sessionMarker})
-        ${pkgs.coreutils}/bin/rm -f ${sessionMarker}
-      fi
-      case "$target" in
-        steamlink)
-          ( ${qtKmsEnv} ${steamlink}/bin/steamlink ) || true
-          ;;
-        moonlight)
-          ( ${qtKmsEnv} ${pkgs.moonlight-qt}/bin/moonlight ) || true
-          ;;
-        nebula)
-          # Firefox kiosk under sway (pinned to 1080p, see swayNebulaConfig).
-          # Nebula serves DRM-free to browsers, so it plays without Widevine.
-          # sc-controller gives the Steam Controller a desktop mapping (trackpad
-          # → mouse, triggers → click) for the browser — but ONLY for this
-          # session: started here, stopped on exit, so Kodi/Steam Link keep
-          # their kernel lizard-mode input. Best-effort: if scc can't grab the
-          # pad (it fights hid-steam over hidraw), the `|| true` lets sway still
-          # run with plain lizard-mode. Logged to /tmp (greetd drops output).
-          ( export MOZ_ENABLE_WAYLAND=1
-            ${pkgs.sc-controller}/bin/scc-daemon --alone ${pkgs.sc-controller}/share/scc/default_profiles/Desktop.sccprofile start >/tmp/scc.log 2>&1 || true
-            ${sway}/bin/sway -c ${swayNebulaConfig}
-            ${pkgs.sc-controller}/bin/scc-daemon --once stop >/dev/null 2>&1 || true
-          ) > /tmp/nebula.log 2>&1 || true
-          ;;
-        *)
-          ${kodiPkg}/bin/kodi || true
-          ;;
-      esac
-      # Guard against a hot loop if an app exits instantly (failed to start).
-      ${pkgs.coreutils}/bin/sleep 1
-    done
-  '';
-
-  # One no-arg launcher per streamer, invoked from a Kodi favourite via
-  # System.Exec: record which app to run next, then SIGTERM Kodi (the GBM binary
-  # is `kodi.bin`, which shuts down cleanly) so greetd reruns eros-shell into it.
-  mkLaunch = app: pkgs.writeShellScript "eros-launch-${app}" ''
-    ${pkgs.coreutils}/bin/echo "${app}" > ${sessionMarker}
-    # Kodi-GBM catches a plain SIGTERM, tears down its input (controller goes
-    # dead) but then hangs without exiting. Escalate from a detached helper that
-    # outlives Kodi — but target THIS Kodi by PID, never a blanket pkill: a
-    # delayed KILL against any "kodi.bin" would land on the freshly-restarted
-    # Kodi (if the next app fails to launch) and crash-loop the session. Once
-    # this Kodi exits, greetd reruns eros-shell into the marker's app.
-    pid="$(${pkgs.procps}/bin/pgrep -x kodi.bin || true)"
-    if [ -n "$pid" ]; then
-      ${pkgs.util-linux}/bin/setsid ${pkgs.bash}/bin/sh -c "
-        ${pkgs.coreutils}/bin/kill -TERM $pid 2>/dev/null || true
-        ${pkgs.coreutils}/bin/sleep 5
-        ${pkgs.coreutils}/bin/kill -KILL $pid 2>/dev/null || true
-      " >/dev/null 2>&1 &
-    fi
-  '';
-  launchSteamlink = mkLaunch "steamlink";
-  launchMoonlight = mkLaunch "moonlight";
-  launchNebula = mkLaunch "nebula";
-
-  # Shipped to ~/.kodi/userdata so the streamers appear under Kodi's Favourites,
-  # navigable with the controller.
-  kodiFavourites = pkgs.writeText "favourites.xml" ''
-    <favourites>
-      <favourite name="Steam Link">System.Exec("${launchSteamlink}")</favourite>
-      <favourite name="Moonlight">System.Exec("${launchMoonlight}")</favourite>
-      <favourite name="Nebula">System.Exec("${launchNebula}")</favourite>
-    </favourites>
-  '';
-
-  # Kodi keeps addon enable-state in userdata/Database/Addons33.db (schema v33 =
-  # Kodi 21). Bundled third-party plugins land there disabled, so Kodi nags
-  # "enable add-on?" on every boot. Pre-enable our addons (jellycon + its Python
-  # deps, plus youtube/inputstream) so it never prompts.
-  kodiAddons = [
-    "plugin.video.jellycon"
-    "script.module.addon.signals"
-    "script.module.dateutil"
-    "script.module.kodi-six"
-    "script.module.six"
-    "script.module.websocket"
-    "plugin.video.youtube"
-    "script.module.inputstreamhelper"
-    "inputstream.adaptive"
-  ];
-  # Flip our addons to enabled=1 in Kodi's addon DB. We do NOT create or migrate
-  # the DB — Kodi owns its schema (and the Addons<N>.db version bumps across
-  # releases); we just upsert the enabled flag once Kodi has created it. Runs
-  # before greetd on every boot, so it takes effect on the next Kodi launch.
-  # (Caveat: the very first boot of a freshly reflashed ~/.kodi has no DB yet, so
-  # Kodi may prompt once that boot; every boot after is clean.)
-  kodiAddonSeed = pkgs.writeShellScript "kodi-addon-seed" ''
-    set -eu
-    db="$HOME/.kodi/userdata/Database/Addons33.db"
-    [ -f "$db" ] || { echo "no addon DB yet (fresh ~/.kodi); skipping"; exit 0; }
-    for a in ${lib.concatStringsSep " " kodiAddons}; do
-      ${pkgs.sqlite}/bin/sqlite3 "$db" \
-        "INSERT INTO installed (addonID,enabled,installDate,disabledReason) VALUES ('$a',1,datetime('now'),0) ON CONFLICT(addonID) DO UPDATE SET enabled=1, disabledReason=0;"
-    done
-  '';
 in
 {
   imports = [
@@ -261,17 +93,14 @@ in
     # video=...e: the display is an LG 4K TV (EDID manufacturer GSM, name
     # "LG TV SSCR2"; native timing 3840x2160@30). We deliberately force 1080p
     # rather than the native 4K — a 4K framebuffer is ~33 MiB and overruns the
-    # swiotlb pool above, and the TV upscales 1080p fine (Steam Link streams
-    # 1080p regardless). The trailing `e` ("output forced on") is the full-KMS
-    # equivalent of the legacy config.txt `hdmi_force_hotplug=1` (which
-    # vc4-kms-v3d + disable_fw_kms_setup ignore). It matters on a TV: TVs drop
-    # HPD/EDID when powered off or on another input, and without `e` a boot
-    # while the TV is off leaves the connector disconnected → vc4 builds no CRTC
-    # (`Cannot find any crtc or sizes`) → Steam Link's eglfs_kms backend crashes
-    # for want of an output, staying blank even once the TV comes back. Forcing
-    # the connector pins it to 1080p regardless of HPD state. Steam Link renders
-    # on HDMI-A-1 (eglfs picks the first forced connector); both ports are
-    # forced so the cable works in either socket.
+    # swiotlb pool above, and the TV upscales 1080p fine. The trailing `e`
+    # ("output forced on") is the full-KMS equivalent of the legacy config.txt
+    # `hdmi_force_hotplug=1`: TVs drop HPD/EDID when powered off or on another
+    # input, and without `e` a boot while the TV is off leaves the connector
+    # disconnected -> vc4 builds no CRTC (`Cannot find any crtc or sizes`) -> the
+    # eglfs/Wayland backend crashes for want of an output, staying blank even
+    # once the TV comes back. Forcing the connector pins it to 1080p regardless
+    # of HPD state. Both ports are forced so the cable works in either socket.
     boot.kernelParams = [
       "swiotlb=131072"
       "video=HDMI-A-1:1920x1080@60e"
@@ -300,6 +129,10 @@ in
       };
     };
 
+    # eros is a lean, cache-only rpi host, so it does NOT use the bundles.users
+    # multi-user machinery (that assigns groups eros lacks — docker/gamemode/
+    # libvirtd — and drags in a heavy HM baseline). The user + home-manager are
+    # wired directly below instead.
     users.users.cramt = {
       isNormalUser = true;
       extraGroups = [ "wheel" "video" "render" "input" "audio" "plugdev" ];
@@ -313,17 +146,37 @@ in
 
     security.sudo.wheelNeedsPassword = false;
 
+    # Minimal home-manager wiring. useGlobalPkgs makes HM inherit the system's
+    # aarch64 pkgs (with the rpi overlays) rather than instantiating its own
+    # nixpkgs; useUserPackages installs into /etc/profiles. The couch shell
+    # (sway + wofi launcher) lives entirely in ./home.nix.
+    home-manager = {
+      useGlobalPkgs = true;
+      useUserPackages = true;
+      users.cramt = import ./home.nix;
+      # desktop.niri (imported unconditionally by mkSystem, like every nixos
+      # module) makes niri-flake inject its HM module into sharedModules for all
+      # users. That module carries a stylix→niri target reading config.stylix.
+      # enable, which is undeclared in HM here because eros runs stylix disabled
+      # (so stylix never injects its HM options). eros's couch shell uses none of
+      # those shared modules, so clear them.
+      sharedModules = lib.mkForce [ ];
+    };
+
     environment.systemPackages = with pkgs; [
       libraspberrypi
       raspberrypi-eeprom
       neovim
       btop
-      steamlink
-      moonlight-qt
-      kodiPkg        # the addon-bundled GBM build; also puts kodi-send on PATH
     ];
 
-    # Audio: pipewire over HDMI. Steam Link's bundled SDL3 talks to PulseAudio,
+    # Emoji + base fonts for the wofi launcher glyphs.
+    fonts = {
+      enableDefaultPackages = true;
+      packages = with pkgs; [ noto-fonts noto-fonts-color-emoji ];
+    };
+
+    # Audio: pipewire over HDMI. Steam Link's bundled SDL talks to PulseAudio,
     # which pipewire-pulse provides.
     services.pulseaudio.enable = false;
     security.rtkit.enable = true;
@@ -339,17 +192,16 @@ in
     services.udev.packages = [ steamlink ];
 
     # Steam Controller. steam-hardware ships the udev rules (also covers the
-    # 2.4 GHz dongle if it ever moves here). The gf keeps the dongle on her
-    # desktop, so eros uses the controller over Bluetooth, where it presents as
-    # a HID mouse+keyboard ("lizard mode") — perfect for driving Kodi, and Steam
-    # Link promotes it to a real gamepad for streamed Steam sessions.
+    # 2.4 GHz dongle if it ever moves here). eros uses the controller over
+    # Bluetooth, where it presents as a HID mouse+keyboard ("lizard mode") — the
+    # couch-shell launcher is driven entirely by that (trackpad->mouse, d-pad->
+    # arrows, A->enter), and Steam Link promotes it to a real gamepad for
+    # streamed sessions. No sc-controller needed.
     hardware.steam-hardware.enable = true;
     hardware.bluetooth.enable = true;
 
     # Re-seed the controller's Bluetooth bond from 1Password so the pairing
     # survives SD-card reflashes (BlueZ bonds live on the SD card otherwise).
-    # Paired once by hand; the bond's `info` file is stored at
-    # op://Homelab/SteamControllerBond/info. Requires /etc/opnix-token present.
     myNixOS.declarativeBluetooth = {
       enable = true;
       devices.steamController = {
@@ -359,63 +211,42 @@ in
       };
     };
 
-    # sway powers the Nebula browser kiosk (Firefox under sway). programs.sway
-    # gives the wrapped package + dbus + polkit; eros-shell launches it
-    # transiently for the nebula session (see the let-binding).
+    # sway is the persistent couch shell. programs.sway gives the wrapped
+    # package + dbus + polkit; greetd launches it and it never exits (the wofi
+    # supervisor loop in home.nix keeps the session alive).
     programs.sway.enable = true;
-    # ...but drop the XDG desktop portals it would pull in: xdg-desktop-portal
-    # 1.20.4 fails its own test suite on this RPi nixpkgs pin (test_dynamiclauncher
-    # + test_notification), which breaks the eros build natively AND blocks the
-    # x86 flash-eros cross-build (uncached aarch64 portal). A Firefox-only Nebula
-    # kiosk doesn't need portals (no file pickers / screen share), so force them off.
+
+    # Drop the XDG desktop portals programs.sway would pull in: xdg-desktop-
+    # portal 1.20.4 fails its own test suite on this rpi nixpkgs pin
+    # (test_dynamiclauncher + test_notification), which breaks the eros build
+    # natively AND blocks the x86 flash-eros cross-build (uncached aarch64
+    # portal). Kept force-off from v1 to preserve buildability.
+    #
+    # NOTE: if the Firefox-kiosk crash turns out to be portal-related, the fix
+    # is to re-enable portals with the failing tests skipped via an overlay
+    # (`xdg-desktop-portal.overrideAttrs (_: { doCheck = false; })`) rather than
+    # nuking them — confirm from /tmp logs on eros first.
     xdg.portal.enable = lib.mkForce false;
 
-    # Boot into the Kodi couch shell via greetd; eros-shell is the session
-    # dispatcher (see the let-binding above) that also lets Kodi favourites
-    # switch the session into Steam Link or Moonlight and back.
+    # Boot straight into sway via greetd. greetd exits whenever its session
+    # command exits, so it simply relaunches sway on any crash/quit — the TV is
+    # never stranded. App switching happens inside sway (the wofi loop), so
+    # there's no greetd churn and none of v1's Kodi kill-dance.
     services.greetd = {
       enable = true;
-      settings = {
-        initial_session = {
-          command = toString erosShell;
-          user = "cramt";
+      settings =
+        let session = { command = "${config.programs.sway.package}/bin/sway"; user = "cramt"; };
+        in {
+          initial_session = session;
+          default_session = session;
         };
-        default_session = {
-          command = toString erosShell;
-          user = "cramt";
-        };
-      };
-    };
-
-    # Ship the Favourites menu (Steam Link / Moonlight launchers) into Kodi's
-    # userdata. tmpfiles creates the dirs so the symlink lands before Kodi's
-    # first run; the target is read-only in the store, which is fine for a kiosk.
-    systemd.tmpfiles.rules = [
-      "d /home/cramt/.kodi 0755 cramt users - -"
-      "d /home/cramt/.kodi/userdata 0755 cramt users - -"
-      "L+ /home/cramt/.kodi/userdata/favourites.xml - - - - ${kodiFavourites}"
-    ];
-
-    # Enable our bundled Kodi addons before Kodi starts, so it never prompts.
-    systemd.services.kodi-addon-seed = {
-      description = "Pre-enable bundled Kodi addons (no enable prompts)";
-      before = [ "greetd.service" ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
-        User = "cramt";
-        ExecStart = toString kodiAddonSeed;
-      };
     };
 
     services.dbus.enable = true;
 
     hardware.enableRedistributableFirmware = true;
 
-    # eros tracks nixos-raspberrypi's nixos-unstable branch (release 26.11),
-    # whose nixpkgs has services.kmscon.config / services.displayManager.generic,
-    # so stylix's targets merge without stubs.
+    # eros tracks nixos-raspberrypi's nixos-unstable branch (release 26.11).
     system.stateVersion = "26.11";
   };
 }

--- a/hosts/eros/home.nix
+++ b/hosts/eros/home.nix
@@ -1,0 +1,210 @@
+# eros couch shell (v2) — home-manager
+#
+# eros is a Raspberry Pi 4B wired to the living-room TV, driven by a Steam
+# Controller over Bluetooth. v1 used Kodi-on-GBM as the shell, which forced a
+# whole-session-switch model (only one app can own the KMS master, and kodi-gbm
+# can't nest a KMS child) — that's where all the v1 hackery lived (marker file,
+# SIGTERM/SIGKILL-Kodi dance, sqlite addon seeding, greetd churn).
+#
+# v2 drops Kodi entirely. sway is the persistent shell; every app (Steam Link,
+# Moonlight, Firefox) is an ordinary Wayland client. The "console menu" is a
+# wofi launcher run in a supervisor loop: show menu -> pick -> run app in the
+# foreground -> app exits -> menu returns. No KMS juggling, no kill dance.
+#
+# Steam Controller: over Bluetooth it presents as a HID mouse+keyboard ("lizard
+# mode") — so the menu is driven natively by the right trackpad (mouse + click)
+# and the d-pad/arrows + A/Enter. No sc-controller needed (that was the flaky
+# bit in v1), which is the whole point of "Steam Controller native" here: the
+# trackpad-as-mouse is the controller's signature strength, so a point-and-click
+# menu IS the native paradigm for this pad.
+{ config, pkgs, lib, ... }:
+let
+  # Their patched Steam Link (aarch64) — same package v1 shipped.
+  steamlink = pkgs.callPackage ../../packages/steamlink { };
+
+  # The addon-configured Firefox (uBlock + SponsorBlock), by store path so the
+  # launcher doesn't depend on PATH inside the greetd-launched sway session.
+  firefox = config.programs.firefox.finalPackage;
+
+  # ---- Destinations -------------------------------------------------------
+  # YouTube's /tv (leanback) UI is built for d-pad navigation — far better on a
+  # controller than the desktop site. Jellyfin + Nebula are plain kiosk tabs.
+  youtubeUrl  = "https://www.youtube.com/tv";
+  jellyfinUrl = "http://jellyfin.lan:8096";   # TODO: point at your Jellyfin server
+  nebulaUrl   = "https://nebula.tv";
+
+  # ---- Launcher styling ---------------------------------------------------
+  wofiConf = pkgs.writeText "eros-wofi.conf" ''
+    show=dmenu
+    width=680
+    height=620
+    location=center
+    prompt=eros
+    insensitive=true
+    allow_markup=true
+    hide_scroll=true
+    no_actions=true
+    lines=7
+    columns=1
+  '';
+
+  wofiStyle = pkgs.writeText "eros-wofi.css" ''
+    * {
+      font-family: "sans-serif";
+      font-size: 32px;
+    }
+    window {
+      background-color: rgba(8, 10, 20, 0.97);
+      border-radius: 22px;
+      padding: 28px;
+    }
+    #input {
+      margin: 8px 8px 18px 8px;
+      padding: 16px 20px;
+      border: none;
+      border-radius: 14px;
+      background-color: rgba(255, 255, 255, 0.06);
+      color: #dfe6f2;
+    }
+    #inner-box { margin: 6px; }
+    #entry {
+      padding: 18px 26px;
+      margin: 5px 8px;
+      border-radius: 16px;
+    }
+    #entry:selected { background-color: #2a6df4; }
+    #text { color: #dfe6f2; }
+    #entry:selected #text { color: #ffffff; }
+  '';
+
+  # ---- The couch shell ----------------------------------------------------
+  # Runs as sway's startup exec. Never returns; a picked app runs in the
+  # foreground and quitting it drops straight back to the menu. Every branch is
+  # `|| true` + a trailing sleep so a failed launch can't hot-loop the TV.
+  #
+  # MOZ_NO_REMOTE forces each `firefox --kiosk` to be its own blocking instance
+  # (otherwise a second invocation just hands the URL to the running one and
+  # returns immediately, flashing the menu).
+  couchShell = pkgs.writeShellScript "eros-couch-shell" ''
+    export MOZ_ENABLE_WAYLAND=1
+    export MOZ_NO_REMOTE=1
+    export QT_QPA_PLATFORM=wayland
+
+    menu() {
+      ${pkgs.wofi}/bin/wofi --dmenu --cache-file /dev/null \
+        --conf ${wofiConf} --style ${wofiStyle} --prompt "eros"
+    }
+
+    while true; do
+      choice=$(${pkgs.coreutils}/bin/printf '%s\n' \
+        "🎮   Steam Link" \
+        "🌙   Moonlight" \
+        "▶    YouTube" \
+        "🎬   Jellyfin" \
+        "🌌   Nebula" \
+        "⏻    Power Off" \
+        "⭮    Restart Shell" | menu) || choice=""
+
+      case "$choice" in
+        *"Steam Link")    ( ${steamlink}/bin/steamlink ) || true ;;
+        *"Moonlight")     ( ${pkgs.moonlight-qt}/bin/moonlight ) || true ;;
+        *"YouTube")       ( ${firefox}/bin/firefox --kiosk "${youtubeUrl}" ) || true ;;
+        *"Jellyfin")      ( ${firefox}/bin/firefox --kiosk "${jellyfinUrl}" ) || true ;;
+        *"Nebula")        ( ${firefox}/bin/firefox --kiosk "${nebulaUrl}" ) || true ;;
+        *"Power Off")     ${pkgs.systemd}/bin/systemctl poweroff || true ;;
+        *"Restart Shell") ${pkgs.sway}/bin/swaymsg exit || true ;;
+        *) : ;;  # Escape / empty selection -> just redraw the menu
+      esac
+      ${pkgs.coreutils}/bin/sleep 1
+    done
+  '';
+in
+{
+  home.username = "cramt";
+  home.homeDirectory = "/home/cramt";
+  home.stateVersion = "26.05";
+
+  home.packages = [
+    pkgs.wofi
+    pkgs.moonlight-qt
+    steamlink
+    pkgs.foot          # lightweight debug terminal (Mod4+Return)
+    pkgs.wl-clipboard
+  ];
+
+  programs.firefox = {
+    enable = true;
+    profiles.default = {
+      extensions.packages = with pkgs.nur.repos.rycee.firefox-addons; [
+        ublock-origin
+        sponsorblock
+      ];
+      settings = {
+        # Kiosk niceties: no close/fullscreen nags, autohide chrome in FS.
+        "browser.aboutConfig.showWarning" = false;
+        "browser.tabs.warnOnClose" = false;
+        "browser.fullscreen.autohide" = true;
+        "full-screen-api.warning.timeout" = 0;
+        "browser.shell.checkDefaultBrowser" = false;
+
+        # --- Pi 4 V3D GPU stability -----------------------------------------
+        # If Firefox crashes / black-screens on launch (the v1 symptom), flip
+        # these on: force software WebRender and disable VA-API. Left off by
+        # default because the earlier "normal compositor" test ran smoother
+        # WITHOUT them, and we want to confirm the real cause from logs first
+        # (the crash may instead be the force-disabled xdg portals — see
+        # configuration.nix). Toggle one axis at a time when testing on eros.
+        # "gfx.webrender.software" = true;
+        # "media.ffmpeg.vaapi.enabled" = false;
+        # "widget.dmabuf.force-enabled" = false;
+      };
+    };
+  };
+
+  wayland.windowManager.sway = {
+    enable = true;
+    xwayland = true;               # Steam Link (SDL) may fall back to XWayland
+    wrapperFeatures.gtk = true;
+    config = {
+      modifier = "Mod4";
+      terminal = "${pkgs.foot}/bin/foot";
+      bars = [ ];                  # kiosk: no status bar
+      gaps = { inner = 0; outer = 0; };
+
+      # Pin 1080p (the kernel video= line already forces it; this keeps sway in
+      # agreement) and paint the background the launcher's dark blue so there's
+      # never a grey flash between the menu closing and an app painting.
+      output."*" = {
+        mode = "1920x1080";
+        bg = "#0a0c14 solid_color";
+      };
+
+      # Single-app kiosk: fullscreen everything, no borders/titlebars. wofi is
+      # a layer-shell surface and is unaffected by these window rules.
+      window = {
+        border = 0;
+        titlebar = false;
+        commands = [
+          { criteria = { app_id = ".*"; }; command = "fullscreen enable, border none"; }
+          { criteria = { class = ".*"; };  command = "fullscreen enable, border none"; }
+        ];
+      };
+      floating = { border = 0; titlebar = false; };
+
+      keybindings = {
+        "Mod4+q" = "kill";                       # force-quit foreground app -> menu
+        "Mod4+Return" = "exec ${pkgs.foot}/bin/foot";
+        "Mod4+Shift+q" = "exec ${pkgs.sway}/bin/swaymsg exit";
+      };
+
+      input."*" = {
+        xkb_layout = "dk";
+        xkb_variant = "nodeadkeys";
+      };
+
+      startup = [
+        { command = "${couchShell}"; always = false; }
+      ];
+    };
+  };
+}


### PR DESCRIPTION
## What

eros v2 — rebuild the living-room Pi 4B's shell around **sway** instead of Kodi-on-GBM.

The v1 shell was Kodi-on-GBM, which owns the KMS master and can't nest a KMS child, forcing a whole-session-switch model. All the v1 hackery lived there: a `/tmp` marker file, a SIGTERM-then-detached-SIGKILL Kodi kill dance, sqlite addon-DB seeding, and greetd churn. v2 deletes all of it.

## How

- **sway is the persistent shell** (greetd launches it, relaunches on exit). Every app — Steam Link, Moonlight, Firefox — is now an ordinary Wayland client, fullscreened by a catch-all window rule.
- **Launcher = a styled `wofi` menu in a supervisor loop** (`hosts/eros/home.nix`): show menu → pick → run app in the foreground → app exits → menu returns. No KMS juggling.
- **Steam Controller native**: over Bluetooth the pad is lizard-mode mouse+keyboard, so the menu is driven by the trackpad (mouse+click) and d-pad/arrows+A — no sc-controller (the flaky v1 component is gone).
- **Firefox declaratively** configured with uBlock Origin + SponsorBlock; YouTube via `youtube.com/tv`, plus Jellyfin (browser) and Nebula tiles.
- **Minimal home-manager wiring** (not `bundles.users`) to keep eros lean/cache-only; `home-manager.sharedModules` cleared because niri-flake's HM injection references stylix options that don't exist on this stylix-disabled host.

## Validation

`nix eval .#nixosConfigurations.eros.config.system.build.toplevel.drvPath` evaluates cleanly. Not built locally (aarch64/qemu is slow) — this PR is opened to let CI build it from scratch and warm cachix.

## Not done / needs on-hardware testing

- Firefox-kiosk crash root cause (v1 symptom) still unconfirmed — needs `/tmp` logs from eros. Stability prefs + the portal caveat are documented inline in `home.nix` / `configuration.nix`.
- Steam Link / Moonlight latency as sway clients (relies on wlroots direct scan-out) — verify on hardware; keep the KMS path as fallback if it regresses.
- Jellyfin server URL is a placeholder (`http://jellyfin.lan:8096`).
- "Phone as keyboard" via KDE Connect is **not** included — confirmed impossible on sway/wlroots (no XDG RemoteDesktop portal for input injection); a Bluetooth-HID phone app is the working alternative.